### PR TITLE
Fixes a realloc portability issue that breaks sdlconq on some platforms.

### DIFF
--- a/kernel/supply.c
+++ b/kernel/supply.c
@@ -379,6 +379,10 @@ init_supply_system(void)
     if (mclass_count) extend_workspace(0);
 
     /* Finally, trim memory taken by material_stats. */
+    if (ms == mstats) {
+		/* Defends against a portability bug */
+		ms = mstats + 1;
+    } 
     if (!realloc(mstats, (size_t)ms - (size_t)mstats)) {
 		Dprintf("realloc() failed; exiting");
 		exit(1);


### PR DESCRIPTION
This simple change fixes a bug that causes sdlconq to reliably break on many systems. When realloc() fails it returns a zero. In the special case where the existing size and new size are the same the realloc() to the difference will thus always appear to fail. This forces a small difference resulting in a tiny non-zero allocation (and consequently both a valid location and response) for that special case.