### PR TITLE
Set BMAP_BYTE to unsigned char always

### DIFF
--- a/kernel/ui.h
+++ b/kernel/ui.h
@@ -7,13 +7,7 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2, or (at your option)
 any later version.  See the file COPYING.  */
 
-/* Try to humor both C++ and pedantic ANSI C. */
-#if (defined (__cplusplus) || defined (__MWERKS__))
-#define BMAP_BYTE char
-#else
 #define BMAP_BYTE unsigned char
-#endif
-
 #define NUMPOWERS 8
 
 /* Xform flags for unit views. */

--- a/x11/xshowimf.c
+++ b/x11/xshowimf.c
@@ -32,12 +32,7 @@ extern "C" {
 }
 #endif
 
-/* Try to humor both C++ and pedantic ANSI C. */
-#ifdef __cplusplus
-#define BMAP_BYTE char
-#else
 #define BMAP_BYTE unsigned char
-#endif
 #include <bitmaps/check.b>
 
 #include "config.h"


### PR DESCRIPTION
This pr sets `BMAP_BYTE` to `unsigned char` always for the following reasons:

1. Bitmap bytes are bytes and not characters.
2. C++ does have an `unsigned char` type (https://en.cppreference.com/w/cpp/language/types#Character_types).
3. The current code is causing compilation errors on modern Ubuntu C++ compilers. E.g. with g++ 9.3.0:
```
g++ -c -g -O2 -fpermissive -Wno-write-strings -g    -DHAVE_ACDEFS_H -I. -I./.. -I./../kernel -I/usr/include/tcl8.6 -I/usr/include/tcl8.6     tkinit.c
In file included from tkinit.c:51:
./../bitmaps/lookglass.b:8:50: error: narrowing conversion of ‘248’ from ‘int’ to ‘char’ [-Wnarrowing]
    8 |    0x00, 0x0c, 0x00, 0x18, 0x00, 0x30, 0x00, 0x20};
      |
```
and with clang++ 10.0:
```
clang++ -c -g -O2 -fpermissive -Wno-write-strings -g    -DHAVE_ACDEFS_H -I. -I./.. -I./../kernel -I/usr/include/tcl8.6 -I/usr/include/tcl8.6     tkinit.c
clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
In file included from tkinit.c:51:
./../bitmaps/lookglass.b:6:4: error: constant expression evaluates to 248 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
   0xf8, 0x00, 0x04, 0x01, 0x02, 0x02, 0x01, 0x04, 0x01, 0x04, 0x01, 0x04,
   ^~~~
```