### PR TITLE
Fix max/min compile errors

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: install
-      run:  sudo apt update && sudo apt install -y tcl-dev tk-dev libsdl2-dev
+      run:  sudo apt update && sudo apt install -y tcl-dev tk-dev libsdl2-dev libxmu-dev
     - name: configure
       run: SDL_CONFIG=/usr/bin/sdl2-config ./configure
     - name: make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: install
-      run:  sudo apt update && sudo apt install -y tcl-dev tk-dev libsdl2-dev libxmu-dev
+      run:  sudo apt update && sudo apt install -y tcl-dev tk-dev libsdl2-dev libxmu-dev libxaw7-dev
     - name: configure
       run: SDL_CONFIG=/usr/bin/sdl2-config ./configure
     - name: make

--- a/kernel/misc.h
+++ b/kernel/misc.h
@@ -41,7 +41,7 @@ any later version.  See the file COPYING.  */
 #endif
 
 #ifdef __cplusplus
-#include <cmath>
+#include <algorithm>
 constexpr const long& min(const long& a, const long& b) {
 	return std::min(a, b);
 }

--- a/kernel/misc.h
+++ b/kernel/misc.h
@@ -40,6 +40,15 @@ any later version.  See the file COPYING.  */
 #define ABS(x) (((x) < 0) ? (0 - (x)) : (x))
 #endif
 
+#ifdef __cplusplus
+#include <cmath>
+constexpr const long& min(const long& a, const long& b) {
+	return std::min(a, b);
+}
+constexpr const long& max(const long& a, const long& b) {
+	return std::max(a, b);
+}
+#else
 #ifndef min
 /*! \brief Minimum value.
  *
@@ -63,6 +72,7 @@ any later version.  See the file COPYING.  */
  */
 #define max(x,y) (((x) > (y)) ? (x) : (y))
 #endif
+#endif /* __cplusplus */
 
 /*! \brief Is between.
  *


### PR DESCRIPTION
This pr fixes #10 by fixing the max/min compile errors reported there. Tested on Ubuntu 24.04 with g++ 13.3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration build environment with expanded system dependencies to improve platform compatibility and build reliability across different configurations.
  * Optimized internal numeric utility functions to enhance overall application performance and code efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->